### PR TITLE
Added `product` fields to spec

### DIFF
--- a/FORMAT_SPEC.md
+++ b/FORMAT_SPEC.md
@@ -9,6 +9,7 @@ This specification originated from discussions in the Altered Programming Discor
 - PolluxTroy
 - xRyzZ
 - Mauc
+- Ajordat
 
 ## General structure
 
@@ -81,30 +82,43 @@ A card with a quantity of 0 SHOULD be omited. It CAN be represented by setting b
 
 Represents a card using the following attributes
 
+* Product
 * Faction
 * Number in faction
 * Rarity
 * (Optional) unique number
 
 This maps directly to a card ID reference, which uses the text format
-`ALT_<set>_<faction>_<number_in_faction>_<rarity>` (optionally followed with a `_<unique_number>` for uniques), e.g. `ALT_CORE_BR_03_C`
+`ALT_<set>_<product>_<faction>_<number_in_faction>_<rarity>` (optionally followed with a `_<unique_number>` for uniques), e.g. `ALT_CORE_B_BR_03_C`
 
 Note that the set is implied from the parent `SetGroup` element.
 
 ```
+int(1) booster_product
+It's 1 if the Product is a booster (_B_), 0 otherwise. If 0, `product` MUST be present.
+
+(Optional) int(2) product
+This MUST be present if and only if booster_product == 0.
+See Product in IDs section
+
 int(3) faction
-see Faction is IDs section
+See Faction in IDs section
 
 int(5) number_in_faction
 Range 0 - 32 (for reference, core set uses range 1-30, and we expect intermediate sets to be smaller).
 
 int(2) rarity
-see Rarity in IDs section
+See Rarity in IDs section
 
 (Optional) int(16) UniqueId
 This MUST be present if and only if rarity == unique (int value 3)
 Range 1 - 65535
 ```
+
+Note that the `booster_product` field is a single bit which works best for the bast majority of cards, which will be acquired through regular means (set boosters or precons).
+If the card is a promo or altered art:
+* Set the `booster_product` field to `0`.
+* Use the `product` field to indicate what type of product it is according to the Product section.
 
 ## IDs
 
@@ -117,6 +131,15 @@ This section contains the list of IDs that map with there respective plain text 
 ```
 1 = COREKS
 2 = CORE
+```
+
+### Product
+
+0 is reserved for future use
+
+```
+1 = P (Promotion: _P_)
+2 = A (AltArt: _A_)
 ```
 
 ### Faction


### PR DESCRIPTION
All the cards indicate their source product on their reference, which distinguishes cards acquired through regular means (set boosters or precons) from promos or (in the future) alternate arts.

This is seen in a card's reference in the third field, which is either `_B_` (most cards), `_P_` (hero promos) or `_A_` (currently unused):

```
{
    "@id": "/card_products/01H1NW5YEN8B72T6CXPYDXV5CZ",
    "@type": "CardProduct",
    "reference": "B",
    "name": "Booster"
},
{
    "@id": "/card_products/01HNWTR4M752KF9JK6J4SH2R6M",
    "@type": "CardProduct",
    "reference": "P",
    "name": "Promotion"
},
{
    "@id": "/card_products/01HTNF0R63ZVZDCJXX0SQ8G55F",
    "@type": "CardProduct",
    "reference": "A",
    "name": "AltArt"
}
```

Currently all cards are being treated as `_B_`, but adding some extra bits to indicate what product the cards belongs to, allows to preserve the use of Promo or Alternate Art cards in a given decklist or collection.

This could be done with 2 bits in the card's specification.
However since the bast majority of cards are expected to come from a booster (`_B_`), I propose to use a single bit to indicate that a card is from a booster and, if not, add two more bits to indicate the actual product (Promo or Alternate Art):

```
int(1) booster_product
It's 1 if the Product is a booster (_B_), 0 otherwise. If 0, `product` MUST be present.

(Optional) int(2) product
This MUST be present if and only if booster_product == 0.
See Product in IDs section
```

I propose the following ID values:
```
1 = P (Promotion: _P_)
2 = A (AltArt: _A_)
```
Note that B (Booster \_B\_) is not part of those IDs because it shouldn't be encoded in the `product` field.
With just two other possible values, this could also be done with 1 single extra bit. However I expect this field to be rarely used, it's more future-proof to use one extra bit with minimal downsides.